### PR TITLE
Added filter, won't show E2103 if the user doesn't have access.

### DIFF
--- a/src/main/kotlin/no/nav/klage/kaka/api/MetadataController.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/api/MetadataController.kt
@@ -9,8 +9,10 @@ import no.nav.klage.kaka.api.view.UserData
 import no.nav.klage.kaka.clients.axsys.AxsysGateway
 import no.nav.klage.kaka.clients.azure.AzureGateway
 import no.nav.klage.kaka.domain.saksbehandler.SaksbehandlerPersonligInfo
+import no.nav.klage.kaka.services.KodeverkResponseService
 import no.nav.klage.kaka.util.TokenUtil
 import no.nav.klage.kaka.util.getLogger
+import no.nav.klage.kodeverk.Enhet
 import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,6 +27,7 @@ class MetadataController(
     private val axsysGateway: AxsysGateway,
     private val azureGateway: AzureGateway,
     private val rolleMapper: RolleMapper,
+    private val kodeverkResponseService: KodeverkResponseService
 ) {
 
     companion object {
@@ -34,7 +37,9 @@ class MetadataController(
 
     @GetMapping("/kodeverk", produces = ["application/json"])
     fun getKodeverk(): KodeverkResponse {
-        return KodeverkResponse()
+        val userHasAccessTo2103 =
+            axsysGateway.getKlageenheterForSaksbehandler(tokenUtil.getIdent()).contains(Enhet.E2103)
+        return kodeverkResponseService.getKodeVerkResponse(userHasAccessTo2103)
     }
 
     @GetMapping("/userdata", produces = ["application/json"])

--- a/src/main/kotlin/no/nav/klage/kaka/api/view/KodeverkResponse.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/api/view/KodeverkResponse.kt
@@ -6,7 +6,7 @@ import no.nav.klage.kodeverk.hjemmel.ytelseTilRegistreringshjemler
 
 data class KodeverkResponse(
     val sakstyper: List<KodeDto> = Type.values().asList().toDto(),
-    val ytelser: List<YtelseKode> = getYtelser(),
+    val ytelser: List<YtelseKode>,
     val utfall: List<KodeDto> = Utfall.values().asList().toDto(),
     val enheter: List<KodeDto> = Enhet.values().asList().toDto(),
     val klageenheter: List<KlageenhetKode> = getKlageenheter(),
@@ -23,15 +23,19 @@ fun getKlageenheter(): List<KlageenhetKode> =
         )
     }
 
-fun getYtelser(): List<YtelseKode> =
+fun getYtelser(include2103: Boolean = false): List<YtelseKode> =
     Ytelse.values().map { ytelse ->
         YtelseKode(
             id = ytelse.id,
             navn = ytelse.navn,
             beskrivelse = ytelse.beskrivelse,
             lovKildeToRegistreringshjemler = ytelseToLovKildeToRegistreringshjemmel[ytelse] ?: emptyList(),
-            enheter = ytelseTilVedtaksenheter[ytelse]?.map { it.toDto() } ?: emptyList(),
-            klageenheter = ytelseTilKlageenheter[ytelse]?.map { it.toDto() } ?: emptyList(),
+            enheter = ytelseTilVedtaksenheter[ytelse]?.filter {
+                it != Enhet.E2103 || include2103
+            }?.map { it.toDto() } ?: emptyList(),
+            klageenheter = ytelseTilKlageenheter[ytelse]?.filter {
+                it != Enhet.E2103 || include2103
+            }?.map { it.toDto() } ?: emptyList(),
         )
     }
 

--- a/src/main/kotlin/no/nav/klage/kaka/services/KodeverkResponseService.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/services/KodeverkResponseService.kt
@@ -1,0 +1,15 @@
+package no.nav.klage.kaka.services
+
+import no.nav.klage.kaka.api.view.KodeverkResponse
+import no.nav.klage.kaka.api.view.getYtelser
+import org.springframework.stereotype.Service
+
+@Service
+class KodeverkResponseService {
+
+    fun getKodeVerkResponse(include2103: Boolean = false): KodeverkResponse {
+        return KodeverkResponse(
+            ytelser = getYtelser(include2103)
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/klage/kaka/services/KodeverkResponseServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/kaka/services/KodeverkResponseServiceTest.kt
@@ -1,0 +1,35 @@
+package no.nav.klage.kaka.services
+
+import no.nav.klage.kaka.api.view.toDto
+import no.nav.klage.kodeverk.Enhet
+import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("local")
+@SpringBootTest(classes = [KodeverkResponseService::class])
+internal class KodeverkResponseServiceTest {
+
+    @Autowired
+    lateinit var kodeverkResponseService: KodeverkResponseService
+
+    @Test
+    fun `kodeverk ytelse does not contain Vikafossen when not specified`() {
+        val kodeverkResponse = kodeverkResponseService.getKodeVerkResponse()
+        assertThat(kodeverkResponse.ytelser).noneSatisfy {
+            assertThat(it.enheter).contains(Enhet.E2103.toDto())
+            assertThat(it.klageenheter).contains(Enhet.E2103.toDto())
+        }
+    }
+
+    @Test
+    fun `kodeverk ytelse contains Vikafossen when specified`() {
+        val kodeverkResponse = kodeverkResponseService.getKodeVerkResponse(true)
+        assertThat(kodeverkResponse.ytelser).allSatisfy {
+            assertThat(it.enheter).contains(Enhet.E2103.toDto())
+            assertThat(it.klageenheter).contains(Enhet.E2103.toDto())
+        }
+    }
+}


### PR DESCRIPTION
Note: The tests won't pass until kodeverk is updated with missing KA-enheter.