### PR TITLE
Saksdata fra kabal anke api

### DIFF
--- a/src/main/kotlin/no/nav/klage/kaka/api/KabalAnkeController.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/api/KabalAnkeController.kt
@@ -24,12 +24,10 @@ import java.util.*
 @Api(tags = ["kaka-api:kabal-kvalitet"])
 @ProtectedWithClaims(issuer = ISSUER_AAD)
 @RequestMapping("/kabalanke")
-class KabalAnkeKvalitetsvurderingController(
+class KabalAnkeController(
     private val kvalitetsvurderingService: KvalitetsvurderingService,
     private val saksdataService: SaksdataService,
     private val tokenUtil: TokenUtil,
-    @Value("\${kabalApiName}")
-    private val kabalApiName: String,
     @Value("\${kabalAnkeApiName}")
     private val kabalAnkeApiName: String,
 ) {
@@ -57,7 +55,7 @@ class KabalAnkeKvalitetsvurderingController(
         val kvalitetsvurdering =
             kvalitetsvurderingService.getKvalitetsvurdering(kvalitetsvurderingId, innloggetSaksbehandler)
         val ytelseToUse = ytelseId?.let { Ytelse.of(it) } ?: Ytelse.OMS_OMP
-        val typeToUse = typeId?.let { Type.of(it) } ?: Type.KLAGE
+        val typeToUse = typeId?.let { Type.of(it) } ?: Type.ANKE
 
         return ValidationErrors(kvalitetsvurdering.getInvalidProperties(ytelseToUse, typeToUse).map {
             ValidationErrors.InvalidProperty(
@@ -94,7 +92,7 @@ class KabalAnkeKvalitetsvurderingController(
 
     private fun verifyAndGetCallingApplication(): String {
         val callingApplication = tokenUtil.getCallingApplication()
-        if (callingApplication !in listOf(kabalApiName, kabalAnkeApiName)) {
+        if (callingApplication !in listOf(kabalAnkeApiName)) {
             throw MissingTilgangException("Calling application not allowed: $callingApplication")
         }
         return callingApplication

--- a/src/main/kotlin/no/nav/klage/kaka/api/KabalAnkeController.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/api/KabalAnkeController.kt
@@ -1,0 +1,102 @@
+package no.nav.klage.kaka.api
+
+import io.swagger.annotations.Api
+import no.nav.klage.kaka.api.view.KabalAnkeSaksdataInput
+import no.nav.klage.kaka.api.view.KabalView
+import no.nav.klage.kaka.api.view.ValidationErrors
+import no.nav.klage.kaka.config.SecurityConfig.Companion.ISSUER_AAD
+import no.nav.klage.kaka.exceptions.MissingTilgangException
+import no.nav.klage.kaka.services.KvalitetsvurderingService
+import no.nav.klage.kaka.services.SaksdataService
+import no.nav.klage.kaka.util.TokenUtil
+import no.nav.klage.kaka.util.getLogger
+import no.nav.klage.kodeverk.Source
+import no.nav.klage.kodeverk.Type
+import no.nav.klage.kodeverk.Utfall
+import no.nav.klage.kodeverk.Ytelse
+import no.nav.klage.kodeverk.hjemmel.Registreringshjemmel
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.*
+import java.util.*
+
+@RestController
+@Api(tags = ["kaka-api:kabal-kvalitet"])
+@ProtectedWithClaims(issuer = ISSUER_AAD)
+@RequestMapping("/kabalanke")
+class KabalAnkeKvalitetsvurderingController(
+    private val kvalitetsvurderingService: KvalitetsvurderingService,
+    private val saksdataService: SaksdataService,
+    private val tokenUtil: TokenUtil,
+    @Value("\${kabalApiName}")
+    private val kabalApiName: String,
+    @Value("\${kabalAnkeApiName}")
+    private val kabalAnkeApiName: String,
+) {
+
+    companion object {
+        @Suppress("JAVA_CLASS_ON_COMPANION")
+        private val logger = getLogger(javaClass.enclosingClass)
+    }
+
+    @PostMapping("/kvalitetsvurdering")
+    fun createKvalitetsvurdering(): KabalView {
+        val callingApplication = verifyAndGetCallingApplication()
+        logger.debug("New kvalitetsvurdering is requested by $callingApplication")
+        return KabalView(kvalitetsvurderingService.createKvalitetsvurdering().id)
+    }
+
+    @GetMapping("/kvalitetsvurdering/{id}/validationerrors")
+    fun getValidationErrors(
+        @PathVariable("id") kvalitetsvurderingId: UUID,
+        @RequestParam temaId: String?,
+        @RequestParam ytelseId: String?,
+        @RequestParam typeId: String?
+    ): ValidationErrors {
+        val innloggetSaksbehandler = tokenUtil.getIdent()
+        val kvalitetsvurdering =
+            kvalitetsvurderingService.getKvalitetsvurdering(kvalitetsvurderingId, innloggetSaksbehandler)
+        val ytelseToUse = ytelseId?.let { Ytelse.of(it) } ?: Ytelse.OMS_OMP
+        val typeToUse = typeId?.let { Type.of(it) } ?: Type.KLAGE
+
+        return ValidationErrors(kvalitetsvurdering.getInvalidProperties(ytelseToUse, typeToUse).map {
+            ValidationErrors.InvalidProperty(
+                field = it.field,
+                reason = it.reason
+            )
+        })
+    }
+
+    @PostMapping("/saksdata")
+    fun createAndFinalizeSaksdata(
+        @RequestBody input: KabalAnkeSaksdataInput
+    ): KabalView {
+        val callingApplication = verifyAndGetCallingApplication()
+        logger.debug("Fullfør kvalitetsvurdering is requested by $callingApplication")
+        return KabalView(
+            saksdataService.createAndFinalizeSaksdataForAnke(
+                sakenGjelder = input.sakenGjelder,
+                sakstype = Type.of(input.sakstype),
+                ytelse = Ytelse.of(input.ytelseId),
+                vedtakKlageinstans = input.vedtakKlageinstans,
+                vedtaksinstansEnhet = input.vedtaksinstansEnhet,
+                mottattVedtaksinstans = input.mottattVedtaksinstans,
+                utfall = Utfall.of(input.utfall),
+                hjemler = input.registreringshjemler?.map { Registreringshjemmel.of(it) } ?: emptyList(),
+                kvalitetsvurderingId = input.kvalitetsvurderingId,
+                avsluttetAvSaksbehandler = input.avsluttetAvSaksbehandler,
+                utfoerendeSaksbehandler = input.utfoerendeSaksbehandler,
+                tilknyttetEnhet = input.tilknyttetEnhet,
+                source = Source.KABAL,
+            ).id
+        )
+    }
+
+    private fun verifyAndGetCallingApplication(): String {
+        val callingApplication = tokenUtil.getCallingApplication()
+        if (callingApplication !in listOf(kabalApiName, kabalAnkeApiName)) {
+            throw MissingTilgangException("Calling application not allowed: $callingApplication")
+        }
+        return callingApplication
+    }
+}

--- a/src/main/kotlin/no/nav/klage/kaka/api/KabalController.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/api/KabalController.kt
@@ -24,14 +24,12 @@ import java.util.*
 @Api(tags = ["kaka-api:kabal-kvalitet"])
 @ProtectedWithClaims(issuer = ISSUER_AAD)
 @RequestMapping("/kabal")
-class KabalKvalitetsvurderingController(
+class KabalController(
     private val kvalitetsvurderingService: KvalitetsvurderingService,
     private val saksdataService: SaksdataService,
     private val tokenUtil: TokenUtil,
     @Value("\${kabalApiName}")
     private val kabalApiName: String,
-    @Value("\${kabalAnkeApiName}")
-    private val kabalAnkeApiName: String,
 ) {
 
     companion object {
@@ -56,8 +54,8 @@ class KabalKvalitetsvurderingController(
         val innloggetSaksbehandler = tokenUtil.getIdent()
         val kvalitetsvurdering =
             kvalitetsvurderingService.getKvalitetsvurdering(kvalitetsvurderingId, innloggetSaksbehandler)
-        val ytelseToUse = ytelseId?.let{ Ytelse.of(it) } ?: Ytelse.OMS_OMP
-        val typeToUse = typeId?.let{ Type.of(it) } ?: Type.KLAGE
+        val ytelseToUse = ytelseId?.let { Ytelse.of(it) } ?: Ytelse.OMS_OMP
+        val typeToUse = typeId?.let { Type.of(it) } ?: Type.KLAGE
 
         return ValidationErrors(kvalitetsvurdering.getInvalidProperties(ytelseToUse, typeToUse).map {
             ValidationErrors.InvalidProperty(
@@ -94,7 +92,7 @@ class KabalKvalitetsvurderingController(
 
     private fun verifyAndGetCallingApplication(): String {
         val callingApplication = tokenUtil.getCallingApplication()
-        if (callingApplication !in listOf(kabalApiName, kabalAnkeApiName)) {
+        if (callingApplication !in listOf(kabalApiName)) {
             throw MissingTilgangException("Calling application not allowed: $callingApplication")
         }
         return callingApplication

--- a/src/main/kotlin/no/nav/klage/kaka/api/view/KabalView.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/api/view/KabalView.kt
@@ -23,6 +23,21 @@ data class KabalSaksdataInput(
     val tilknyttetEnhet: String,
 )
 
+data class KabalAnkeSaksdataInput(
+    val sakenGjelder: String,
+    val sakstype: String,
+    val ytelseId: String,
+    val mottattVedtaksinstans: LocalDate,
+    val vedtaksinstansEnhet: String,
+    val vedtakKlageinstans: LocalDateTime,
+    val utfall: String,
+    val registreringshjemler: List<String>?,
+    val utfoerendeSaksbehandler: String,
+    val kvalitetsvurderingId: UUID,
+    val avsluttetAvSaksbehandler: LocalDateTime,
+    val tilknyttetEnhet: String,
+)
+
 data class ValidationErrors(
     val validationErrors: List<InvalidProperty>
 ) {

--- a/src/main/kotlin/no/nav/klage/kaka/api/view/KabalView.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/api/view/KabalView.kt
@@ -29,7 +29,7 @@ data class KabalAnkeSaksdataInput(
     val ytelseId: String,
     val mottattVedtaksinstans: LocalDate,
     val vedtaksinstansEnhet: String,
-    val vedtakKlageinstans: LocalDateTime,
+    val vedtakKlageinstans: LocalDate,
     val utfall: String,
     val registreringshjemler: List<String>?,
     val utfoerendeSaksbehandler: String,

--- a/src/main/kotlin/no/nav/klage/kaka/domain/Saksdata.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/domain/Saksdata.kt
@@ -36,7 +36,7 @@ class Saksdata(
     @Column(name = "dato_mottatt_klageinstans")
     var mottattKlageinstans: LocalDate? = null,
     @Column(name = "dato_vedtak_klageinstans")
-    var vedtakKlageinstans: LocalDateTime? = null,
+    var vedtakKlageinstans: LocalDate? = null,
     @Column(name = "utfall_id")
     @Convert(converter = UtfallConverter::class)
     var utfall: Utfall? = null,

--- a/src/main/kotlin/no/nav/klage/kaka/domain/Saksdata.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/domain/Saksdata.kt
@@ -35,6 +35,8 @@ class Saksdata(
     var vedtaksinstansEnhet: String? = null,
     @Column(name = "dato_mottatt_klageinstans")
     var mottattKlageinstans: LocalDate? = null,
+    @Column(name = "dato_vedtak_klageinstans")
+    var vedtakKlageinstans: LocalDateTime? = null,
     @Column(name = "utfall_id")
     @Convert(converter = UtfallConverter::class)
     var utfall: Utfall? = null,

--- a/src/main/kotlin/no/nav/klage/kaka/services/SaksdataService.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/services/SaksdataService.kt
@@ -102,7 +102,7 @@ class SaksdataService(
         ytelse: Ytelse,
         mottattVedtaksinstans: LocalDate,
         vedtaksinstansEnhet: String,
-        vedtakKlageinstans: LocalDateTime,
+        vedtakKlageinstans: LocalDate,
         utfall: Utfall,
         hjemler: List<Registreringshjemmel>,
         utfoerendeSaksbehandler: String,

--- a/src/main/kotlin/no/nav/klage/kaka/services/SaksdataService.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/services/SaksdataService.kt
@@ -96,6 +96,42 @@ class SaksdataService(
         }
     }
 
+    fun createAndFinalizeSaksdataForAnke(
+        sakenGjelder: String,
+        sakstype: Type,
+        ytelse: Ytelse,
+        mottattVedtaksinstans: LocalDate,
+        vedtaksinstansEnhet: String,
+        vedtakKlageinstans: LocalDateTime,
+        utfall: Utfall,
+        hjemler: List<Registreringshjemmel>,
+        utfoerendeSaksbehandler: String,
+        tilknyttetEnhet: String,
+        kvalitetsvurderingId: UUID,
+        avsluttetAvSaksbehandler: LocalDateTime,
+        source: Source
+    ): Saksdata {
+        //TODO: Her skal det skje en validering før noen oppdatering skjer.
+        kvalitetsvurderingService.cleanUpKvalitetsvurdering(kvalitetsvurderingId)
+        return saksdataRepository.save(
+            Saksdata(
+                sakenGjelder = sakenGjelder,
+                sakstype = sakstype,
+                ytelse = ytelse,
+                vedtakKlageinstans = vedtakKlageinstans,
+                vedtaksinstansEnhet = vedtaksinstansEnhet,
+                mottattVedtaksinstans = mottattVedtaksinstans,
+                utfall = utfall,
+                registreringshjemler = hjemler.toSet(),
+                avsluttetAvSaksbehandler = avsluttetAvSaksbehandler,
+                utfoerendeSaksbehandler = utfoerendeSaksbehandler,
+                tilknyttetEnhet = tilknyttetEnhet,
+                kvalitetsvurdering = kvalitetsvurderingRepository.getById(kvalitetsvurderingId),
+                source = source
+            )
+        )
+    }
+
     fun setSakenGjelder(saksdataId: UUID, sakenGjelder: String, innloggetSaksbehandler: String): Saksdata {
         val saksdata = getSaksdataAndVerifyAccessForEdit(saksdataId, innloggetSaksbehandler)
         saksdata.sakenGjelder = sakenGjelder

--- a/src/main/resources/db/migration/V1_7__Add_dato_vedtak_klageinstans.sql
+++ b/src/main/resources/db/migration/V1_7__Add_dato_vedtak_klageinstans.sql
@@ -1,0 +1,2 @@
+ALTER TABLE kaka.saksdata
+    ADD COLUMN dato_vedtak_klageinstans TIMESTAMP;

--- a/src/main/resources/db/migration/V1_7__Add_dato_vedtak_klageinstans.sql
+++ b/src/main/resources/db/migration/V1_7__Add_dato_vedtak_klageinstans.sql
@@ -1,2 +1,2 @@
 ALTER TABLE kaka.saksdata
-    ADD COLUMN dato_vedtak_klageinstans TIMESTAMP;
+    ADD COLUMN dato_vedtak_klageinstans DATE;


### PR DESCRIPTION
Lagt til støtte for saksdata fra kabal-anke-api med en egen contoller, og lagt til nytt for vedtakKlageinstans i db og i Saksdata-entityen. Mangler å kunne vise/editere i gui, samt eksport til statistikk og Excel mm.

