### PR TITLE
Initialise modified with exact same value as created

### DIFF
--- a/src/main/kotlin/no/nav/klage/kaka/domain/kvalitetsvurdering/v1/KvalitetsvurderingV1.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/domain/kvalitetsvurdering/v1/KvalitetsvurderingV1.kt
@@ -103,7 +103,7 @@ class KvalitetsvurderingV1(
     @Column(name = "created")
     val created: LocalDateTime = LocalDateTime.now(),
     @Column(name = "modified")
-    var modified: LocalDateTime = LocalDateTime.now()
+    var modified: LocalDateTime = created
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/no/nav/klage/kaka/domain/kvalitetsvurdering/v2/KvalitetsvurderingV2.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/domain/kvalitetsvurdering/v2/KvalitetsvurderingV2.kt
@@ -145,7 +145,7 @@ class KvalitetsvurderingV2(
 
     var annetFritekst: String? = null,
     val created: LocalDateTime = LocalDateTime.now(),
-    var modified: LocalDateTime = LocalDateTime.now()
+    var modified: LocalDateTime = created
 ) {
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/no/nav/klage/kaka/domain/kvalitetsvurdering/v3/KvalitetsvurderingV3.kt
+++ b/src/main/kotlin/no/nav/klage/kaka/domain/kvalitetsvurdering/v3/KvalitetsvurderingV3.kt
@@ -246,7 +246,7 @@ class KvalitetsvurderingV3(
     val created: LocalDateTime = LocalDateTime.now(),
 
     @Column(name = "modified")
-    var modified: LocalDateTime = LocalDateTime.now()
+    var modified: LocalDateTime = created
 ) {
 
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
FE compares `created` and `modified` to check if any changes have been made to the kvalitetsvurdering.

Today `created` and `modified` are initialised with `LocalDateTime.now()` separately, making them differ by a few milliseconds.

Referencing `created` for `modified` makes their initial values equal.